### PR TITLE
Add Robby Manihani as undergraduate student

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -97,6 +97,11 @@ hangookang:
   title: Master's Researcher
 
 
+robbymanihani:
+  name: Robby Manihani
+  url: https://www.linkedin.com/in/grmanihani/
+  title: Undergraduate Student
+
 tanvirbhathal:
   name: Tanvir Bhathal
   url: https://www.linkedin.com/in/tanvir-bhathal/


### PR DESCRIPTION
## Summary
- Adds Robby Manihani to `_data/people.yml` as an Undergraduate Student
- LinkedIn: https://www.linkedin.com/in/grmanihani/

🤖 Generated with [Claude Code](https://claude.com/claude-code)